### PR TITLE
fix equals using getClass() instead of instanceof.

### DIFF
--- a/sulky-ulid/src/main/java/de/huxhorn/sulky/ulid/ULID.java
+++ b/sulky-ulid/src/main/java/de/huxhorn/sulky/ulid/ULID.java
@@ -324,7 +324,7 @@ public class ULID
 		public boolean equals(Object o)
 		{
 			if (this == o) return true;
-			if (o == null || getClass() != o.getClass()) return false;
+			if (!(o instanceof Value)) return false;
 
 			Value value = (Value) o;
 


### PR DESCRIPTION
Probably unwanted `getClass()` in the equals method. `getClass()` should only be used for proxiable objects, like JPA’s entity classes (e.g. implemented by hibernate, eclipselink, etc).
Every other class should not add fields and thus must comply to the java spec which forbids mutation by adding fields. Thus, the subclass must comply to using equals with the `instanceof` keyword.